### PR TITLE
Fix lack of context.Background()

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/google/go-github/github"
 	"github.com/olekukonko/tablewriter"
 )
@@ -53,7 +55,7 @@ func main() {
 	var issues []*github.Issue
 
 	for len(issues) <= *amount || *amount < 0 {
-		newIssues, resp, err := client.Issues.ListByRepo(path[1], path[2], opt)
+		newIssues, resp, err := client.Issues.ListByRepo(context.Background(), path[1], path[2], opt)
 		if err != nil {
 			log.Fatalf("error fetching issues for %v/%v: %v", path[1], path[2], err)
 		}


### PR DESCRIPTION
Prior to this fix, a build results in:

```
./main.go:56: not enough arguments in call to client.Issues.ListByRepo
	have (string, string, *github.IssueListByRepoOptions)
	want (context.Context, string, string, *github.IssueListByRepoOptions)
```